### PR TITLE
Fix section name

### DIFF
--- a/blueprints/tabs/page.yml
+++ b/blueprints/tabs/page.yml
@@ -6,7 +6,7 @@ columns:
   settings:
     width: 2/3
     sections:
-      fields:
+      seoFields:
         type: fields
         fields:
           metaHeadline:

--- a/blueprints/tabs/site.yml
+++ b/blueprints/tabs/site.yml
@@ -5,7 +5,7 @@ extends: seo/tabs/page
 columns:
   settings:
     sections:
-      fields:
+      seoFields:
         fields:
           metaTitle: false # Global fallback meta title does not make sense
           metaDescription:


### PR DESCRIPTION
The section named `fields` collided with other `fields` sections in a projects site.yml